### PR TITLE
updated solid-client for RDF prefixes, but Jest unit tests fail

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -14,5 +14,7 @@ resources
 
 jest.config.js
 jest.e2e.config.js
+jest.setup.js
+jest.e2e.config.js
 rollup.config.js
 tsconfig.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         # critical.
         # os: [ubuntu-20.04, windows-2019, macos-10.15]
         os: [ubuntu-20.04, windows-2019]
-        node-version: [16.x, 14.x]
+        node-version: [18.x, 16.x]
     steps:
     - uses: actions/checkout@v2.3.4
     - name: Use Node.js ${{ matrix.node-version }}

--- a/e2e/node/ExtractTransform-display.test.ts
+++ b/e2e/node/ExtractTransform-display.test.ts
@@ -64,6 +64,10 @@ import {
   hobbyTransform,
 } from "../../src/dataSource/clientHobbyFile";
 
+import { DataFactory } from "rdf-data-factory";
+import * as RDFJS from "rdf-js";
+const factory: RDFJS.DataFactory = new DataFactory();
+
 // Load environment variables from .env.test.local if available:
 config({
   default_node_env: process.env.NODE_ENV || "test",
@@ -179,14 +183,20 @@ describe("All data sources", () => {
 
         const companyResource = getThingOfTypeFromCollectionMandatoryOne(
           resourceDetails,
-          SCHEMA_INRUPT.NS("Organization")
+          // SCHEMA_INRUPT.Organization
+          factory.namedNode("https://schema.org/Organization")
         );
         const addressResource = getThingOfTypeFromCollectionMandatoryOne(
           resourceDetails,
-          SCHEMA_INRUPT.PostalAddress
+          // SCHEMA_INRUPT.PostalAddress
+          factory.namedNode("https://schema.org/PostalAddress")
         );
 
-        const name = getStringNoLocale(companyResource, SCHEMA_INRUPT.name);
+        // const name = getStringNoLocale(companyResource, SCHEMA_INRUPT.name);
+        const name = getStringNoLocale(
+          companyResource,
+          factory.namedNode("https://schema.org/name")
+        );
         const status = getStringNoLocale(
           companyResource,
           INRUPT_3RD_PARTY_COMPANIES_HOUSE_UK.status
@@ -194,23 +204,28 @@ describe("All data sources", () => {
 
         const streetAddress = getStringNoLocale(
           addressResource,
-          SCHEMA_INRUPT.streetAddress
+          // SCHEMA_INRUPT.streetAddress
+          factory.namedNode("https://schema.org/streetAddress")
         );
         const locality = getStringNoLocale(
           addressResource,
-          SCHEMA_INRUPT.addressLocality
+          // SCHEMA_INRUPT.addressLocality
+          factory.namedNode("https://schema.org/addressLocality")
         );
         const region = getStringNoLocale(
           addressResource,
-          SCHEMA_INRUPT.addressRegion
+          // SCHEMA_INRUPT.addressRegion
+          factory.namedNode("https://schema.org/addressRegion")
         );
         const country = getStringNoLocale(
           addressResource,
-          SCHEMA_INRUPT.addressCountry
+          // SCHEMA_INRUPT.addressCountry
+          factory.namedNode("https://schema.org/addressCountry")
         );
         const postCode = getStringNoLocale(
           addressResource,
-          SCHEMA_INRUPT.postalCode
+          // SCHEMA_INRUPT.postalCode
+          factory.namedNode("https://schema.org/postalCode")
         );
 
         debug(`Company details: name [${name}], status [${status}].`);

--- a/e2e/node/ExtractTransform-display.test.ts
+++ b/e2e/node/ExtractTransform-display.test.ts
@@ -101,7 +101,10 @@ describe("All data sources", () => {
         const resourceDetails: CollectionOfResources = passportTransform(
           credential,
           response,
-          `${process.env.SOLID_STORAGE_ROOT!}${APPLICATION_ENTRYPOINT}`
+          `${
+            process.env.SOLID_STORAGE_ROOT ||
+            "https://valid-iri-if-none-provided.example.com/"
+          }${APPLICATION_ENTRYPOINT}`
         );
         expect(resourceDetails.rdfResources).toHaveLength(3);
 
@@ -137,7 +140,10 @@ describe("All data sources", () => {
         const resourceDetails: CollectionOfResources = hobbyTransform(
           credential,
           response,
-          `${process.env.SOLID_STORAGE_ROOT!}${APPLICATION_ENTRYPOINT}`
+          `${
+            process.env.SOLID_STORAGE_ROOT ||
+            "https://valid-iri-if-none-provided.example.com/"
+          }${APPLICATION_ENTRYPOINT}`
         );
         expect(resourceDetails.rdfResources).toHaveLength(4);
 
@@ -178,7 +184,10 @@ describe("All data sources", () => {
           companiesHouseUkTransformCompany(
             credential,
             response,
-            `${process.env.SOLID_STORAGE_ROOT!}${APPLICATION_ENTRYPOINT}`
+            `${
+              process.env.SOLID_STORAGE_ROOT ||
+              "https://valid-iri-if-none-provided.example.com/"
+            }${APPLICATION_ENTRYPOINT}`
           );
 
         const companyResource = getThingOfTypeFromCollectionMandatoryOne(

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,5 +1,5 @@
-/**
- * Copyright 2020 Inrupt Inc.
+/*
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in
@@ -19,30 +19,4 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "jsdom",
-  clearMocks: true,
-  collectCoverage: true,
-  coverageThreshold: {
-    global: {
-      branches: 100,
-      functions: 100,
-      lines: 100,
-      statements: 100,
-    },
-  },
-  coveragePathIgnorePatterns: [
-    "/node_modules/",
-    "/src/InruptTooling/",
-    "<rootDir>/dist",
-  ],
-  testPathIgnorePatterns: [
-    "/node_modules/",
-    "/src/InruptTooling/",
-    // By default we only run unit tests:
-    "/src/e2e-node/",
-    "/src/e2e-browser/",
-  ],
-  setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
-};
+require("@inrupt/jest-jsdom-polyfills");

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,8 +49,8 @@
         "license-checker": "^25.0.1",
         "lint-staged": "^12.3.2",
         "prettier": "2.5.1",
-        "rollup": "^2.66.1",
-        "rollup-plugin-typescript2": "^0.30.0",
+        "rollup": "^3.28.1",
+        "rollup-plugin-typescript2": "^0.35.0",
         "ts-jest": "^27.1.3",
         "ts-node": "^10.8.1",
         "typescript": "^4.6.2"
@@ -1618,12 +1618,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/@peculiar/json-schema": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
@@ -1651,12 +1645,6 @@
       "engines": {
         "node": ">=10.12.0"
       }
-    },
-    "node_modules/@peculiar/webcrypto/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
     },
     "node_modules/@rdfjs/data-model": {
       "version": "1.3.4",
@@ -2527,12 +2515,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/asn1js/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
@@ -4238,17 +4220,17 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=6 <7 || >=8"
+        "node": ">=12"
       }
     },
     "node_modules/fs.realpath": {
@@ -5956,10 +5938,13 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -7268,12 +7253,6 @@
         "tslib": "^2.6.1"
       }
     },
-    "node_modules/pvtsutils/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
-    },
     "node_modules/pvutils": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
@@ -7687,48 +7666,36 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.75.7",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.75.7.tgz",
-      "integrity": "sha512-VSE1iy0eaAYNCxEXaleThdFXqZJ42qDBatAwrfnPlENEZ8erQ+0LYX4JXOLPceWfZpV1VtZwZ3dFCuOZiSyFtQ==",
+      "version": "3.28.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.1.tgz",
+      "integrity": "sha512-R9OMQmIHJm9znrU3m3cpE8uhN0fGdXiawME7aZIpQqvpS/85+Vt1Hq1/yVIcYfOmaQiHjvXkQAoJukvLpau6Yw==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
     },
     "node_modules/rollup-plugin-typescript2": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.30.0.tgz",
-      "integrity": "sha512-NUFszIQyhgDdhRS9ya/VEmsnpTe+GERDMmFo0Y+kf8ds51Xy57nPNGglJY+W6x1vcouA7Au7nsTgsLFj2I0PxQ==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.35.0.tgz",
+      "integrity": "sha512-szcIO9hPUx3PhQl91u4pfNAH2EKbtrXaES+m163xQVE5O1CC0ea6YZV/5woiDDW3CR9jF2CszPrKN+AFiND0bg==",
       "dev": true,
       "dependencies": {
-        "@rollup/pluginutils": "^4.1.0",
-        "find-cache-dir": "^3.3.1",
-        "fs-extra": "8.1.0",
-        "resolve": "1.20.0",
-        "tslib": "2.1.0"
+        "@rollup/pluginutils": "^4.1.2",
+        "find-cache-dir": "^3.3.2",
+        "fs-extra": "^10.0.0",
+        "semver": "^7.3.7",
+        "tslib": "^2.4.0"
       },
       "peerDependencies": {
         "rollup": ">=1.26.3",
         "typescript": ">=2.4.0"
-      }
-    },
-    "node_modules/rollup-plugin-typescript2/node_modules/resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/run-parallel": {
@@ -8603,9 +8570,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
     },
     "node_modules/tsutils": {
@@ -8711,12 +8678,12 @@
       }
     },
     "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true,
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -8927,12 +8894,6 @@
         "pvtsutils": "^1.3.2",
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/webcrypto-core/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
@@ -10511,14 +10472,6 @@
         "asn1js": "^3.0.5",
         "pvtsutils": "^1.3.2",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-          "dev": true
-        }
       }
     },
     "@peculiar/json-schema": {
@@ -10541,14 +10494,6 @@
         "pvtsutils": "^1.3.2",
         "tslib": "^2.5.0",
         "webcrypto-core": "^1.7.7"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-          "dev": true
-        }
       }
     },
     "@rdfjs/data-model": {
@@ -11216,14 +11161,6 @@
         "pvtsutils": "^1.3.2",
         "pvutils": "^1.1.3",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-          "dev": true
-        }
       }
     },
     "astral-regex": {
@@ -12510,14 +12447,14 @@
       }
     },
     "fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       }
     },
     "fs.realpath": {
@@ -13756,12 +13693,13 @@
       "dev": true
     },
     "jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
       }
     },
     "jsonld-context-parser": {
@@ -14755,14 +14693,6 @@
       "dev": true,
       "requires": {
         "tslib": "^2.6.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-          "dev": true
-        }
       }
     },
     "pvutils": {
@@ -15090,37 +15020,25 @@
       }
     },
     "rollup": {
-      "version": "2.75.7",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.75.7.tgz",
-      "integrity": "sha512-VSE1iy0eaAYNCxEXaleThdFXqZJ42qDBatAwrfnPlENEZ8erQ+0LYX4JXOLPceWfZpV1VtZwZ3dFCuOZiSyFtQ==",
+      "version": "3.28.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.1.tgz",
+      "integrity": "sha512-R9OMQmIHJm9znrU3m3cpE8uhN0fGdXiawME7aZIpQqvpS/85+Vt1Hq1/yVIcYfOmaQiHjvXkQAoJukvLpau6Yw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
       }
     },
     "rollup-plugin-typescript2": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.30.0.tgz",
-      "integrity": "sha512-NUFszIQyhgDdhRS9ya/VEmsnpTe+GERDMmFo0Y+kf8ds51Xy57nPNGglJY+W6x1vcouA7Au7nsTgsLFj2I0PxQ==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.35.0.tgz",
+      "integrity": "sha512-szcIO9hPUx3PhQl91u4pfNAH2EKbtrXaES+m163xQVE5O1CC0ea6YZV/5woiDDW3CR9jF2CszPrKN+AFiND0bg==",
       "dev": true,
       "requires": {
-        "@rollup/pluginutils": "^4.1.0",
-        "find-cache-dir": "^3.3.1",
-        "fs-extra": "8.1.0",
-        "resolve": "1.20.0",
-        "tslib": "2.1.0"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "1.20.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
-          }
-        }
+        "@rollup/pluginutils": "^4.1.2",
+        "find-cache-dir": "^3.3.2",
+        "fs-extra": "^10.0.0",
+        "semver": "^7.3.7",
+        "tslib": "^2.4.0"
       }
     },
     "run-parallel": {
@@ -15759,9 +15677,9 @@
       }
     },
     "tslib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
     },
     "tsutils": {
@@ -15838,9 +15756,9 @@
       }
     },
     "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true
     },
     "update-browserslist-db": {
@@ -16018,14 +15936,6 @@
         "asn1js": "^3.0.1",
         "pvtsutils": "^1.3.2",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-          "dev": true
-        }
       }
     },
     "webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,13 @@
       "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
-        "@inrupt/solid-client": "1.26.0",
-        "@inrupt/solid-client-authn-node": "1.14.0",
+        "@inrupt/solid-client": "^1.30.0",
+        "@inrupt/solid-client-authn-node": "^1.17.1",
         "@inrupt/vocab-common-rdf-rdfdatafactory": "1.0.3",
         "@inrupt/vocab-etl-tutorial-bundle-all-rdfdatafactory": "file:./src/InruptTooling/Vocab/EtlTutorial/Generated/SourceCodeArtifacts/TypeScript-RdfDataFactory",
         "@inrupt/vocab-inrupt-core-rdfdatafactory": "1.0.3",
         "@rdfjs/dataset": "^1.1.1",
         "@rdfjs/types": "^1.0.1",
-        "cross-fetch": "^3.1.4",
         "debug": "^4.3.3",
         "glob": "^7.2.0",
         "rdf-data-factory": "^1.1.0",
@@ -24,8 +23,8 @@
         "yargs": "^17.3.1"
       },
       "devDependencies": {
-        "@inrupt/eslint-config-base": "^0.3.0",
         "@inrupt/eslint-config-lib": "^0.3.0",
+        "@inrupt/jest-jsdom-polyfills": "^2.1.3",
         "@inrupt/vocab-inrupt-test-rdfdatafactory": "^1.0.3",
         "@skypack/package-check": "^0.2.2",
         "@types/debug": "^4.1.7",
@@ -49,7 +48,7 @@
         "jest": "^27.4.7",
         "license-checker": "^25.0.1",
         "lint-staged": "^12.3.2",
-        "prettier": "^2.5.1",
+        "prettier": "2.5.1",
         "rollup": "^2.66.1",
         "rollup-plugin-typescript2": "^0.30.0",
         "ts-jest": "^27.1.3",
@@ -134,9 +133,9 @@
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -189,9 +188,9 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -673,6 +672,17 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@bergos/jsonparse": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@bergos/jsonparse/-/jsonparse-1.4.1.tgz",
+      "integrity": "sha512-vXIT0nzZGX/+yMD5bx2VhTzc92H55tPoehh1BW/FZHOndWGFddrH3MAfdx39FRc7irABirW6EQaGxIJYV6CGuA==",
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "dependencies": {
+        "buffer": "^6.0.3"
+      }
+    },
     "node_modules/@comunica/actor-abstract-mediatyped": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.2.0.tgz",
@@ -954,19 +964,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@digitalbazaar/http-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-1.2.0.tgz",
-      "integrity": "sha512-W9KQQ5pUJcaR0I4c2HPJC0a7kRbZApIorZgPnEDwMBgj16iQzutGLrCXYaZOmxqVLVNqqlQ4aUJh+HBQZy4W6Q==",
-      "dependencies": {
-        "esm": "^3.2.22",
-        "ky": "^0.25.1",
-        "ky-universal": "^0.8.2"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -1021,6 +1018,7 @@
       "resolved": "https://registry.npmjs.org/@inrupt/eslint-config-base/-/eslint-config-base-0.3.0.tgz",
       "integrity": "sha512-wHekhVgAIzoaL5oTXZN99dWws+nxKlbMfhyTsqQzL8hB9q8lC0rfbcKd4B3K0V4zRuhjuicH4YH7LTcJAgUvKA==",
       "dev": true,
+      "peer": true,
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.6.0",
         "@typescript-eslint/parser": "^5.6.0",
@@ -1044,54 +1042,111 @@
         "@inrupt/eslint-config-base": "^0.3.0"
       }
     },
-    "node_modules/@inrupt/solid-client": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.26.0.tgz",
-      "integrity": "sha512-fiu5z4GHVXgsUlGSWOtxDQBPyQEcXx41Q8JiTem/qJ5oD8OPwJL+mjymJnoMfxyW+jVa5nq4XsF8GnFrF74niQ==",
+    "node_modules/@inrupt/jest-jsdom-polyfills": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-2.1.3.tgz",
+      "integrity": "sha512-0+yVUdAJ7v5L5JzvqjGdVlDSLdC17yHXStZSNGoXSnUns9OH/Jn3pQFu2IppBMYxyzAbPor7R2geGNtFoqRuig==",
+      "dev": true,
       "dependencies": {
+        "@peculiar/webcrypto": "^1.4.0",
+        "@web-std/blob": "^3.0.4",
+        "@web-std/file": "^3.0.2",
+        "undici": "^5.23.0"
+      }
+    },
+    "node_modules/@inrupt/solid-client": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.30.0.tgz",
+      "integrity": "sha512-iRyLqM9k5W0IiRHZz+dGsa+94pu8cGqjRB5B8s+YhLlNQH/fY6Xmu21f1zl1uKWebc4PBlAJPcBcR46RVXlCJQ==",
+      "dependencies": {
+        "@inrupt/universal-fetch": "^1.0.1",
         "@rdfjs/dataset": "^1.1.0",
         "@types/rdfjs__dataset": "^1.0.4",
-        "cross-fetch": "^3.0.4",
+        "buffer": "^6.0.3",
         "http-link-header": "^1.1.0",
-        "jsonld": "^5.2.0",
+        "jsonld-context-parser": "^2.3.0",
+        "jsonld-streaming-parser": "^3.2.0",
         "n3": "^1.10.0",
         "uuid": "^9.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.0.0"
+        "node": "^14.17.0 || ^16.0.0 || ^18.0.0 || ^20.0.0"
       },
       "optionalDependencies": {
         "fsevents": "^2.3.2"
       }
     },
     "node_modules/@inrupt/solid-client-authn-core": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.14.0.tgz",
-      "integrity": "sha512-/H05XiMpgRjhHECT4Pku1jHlQoRzP4H5kcgZH+dbc54mMYrglBuCHXNGgW967zcg0eiCn0NROdovy8r4vl1LWQ==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.17.1.tgz",
+      "integrity": "sha512-UKTtZH0lISgWaiUYRr0zRkvFHIjYzVaWEC0IJoLUFIEfJdYogMXmPKoHyJEw7MdJ6qVYMLdPo9k2OSLfdUfYjA==",
       "dependencies": {
-        "cross-fetch": "^3.1.5",
+        "@inrupt/universal-fetch": "^1.0.1",
         "events": "^3.3.0",
         "jose": "^4.10.0",
-        "lodash.clonedeep": "^4.5.0",
         "uuid": "^9.0.0"
       },
       "engines": {
-        "node": "^14.0.0 || ^16.0.0"
+        "node": "^14.0.0 || ^16.0.0 || ^18.0.0 || ^20.0.0"
       }
     },
     "node_modules/@inrupt/solid-client-authn-node": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.14.0.tgz",
-      "integrity": "sha512-9CPJ9iDBx16ddUR1KxqJIb/fpW2tH6AMb4tCjGB2CgeZXnF+6PR9yeoDlKMMQy0m7GBkj7E5tUadIL3RmQ9pYw==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.17.1.tgz",
+      "integrity": "sha512-4ISQPIz6mIcTLk2sVUEc6q7iD69SuXP50P1A8y8qAAzh/UvFyl2MDwCCXS7+WTpaYKAo2uc54WyYuJhDnu/Ujw==",
       "dependencies": {
-        "@inrupt/solid-client-authn-core": "^1.14.0",
-        "cross-fetch": "^3.1.5",
+        "@inrupt/solid-client-authn-core": "^1.17.1",
+        "@inrupt/universal-fetch": "^1.0.1",
         "jose": "^4.3.7",
-        "openid-client": "^5.1.0",
+        "openid-client": "~5.4.2",
         "uuid": "^9.0.0"
       },
       "engines": {
-        "node": "^14.0.0 || ^16.0.0"
+        "node": "^14.0.0 || ^16.0.0 || ^18.0.0 || ^20.0.0"
+      }
+    },
+    "node_modules/@inrupt/solid-client/node_modules/jsonld-streaming-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-3.2.0.tgz",
+      "integrity": "sha512-lJR1SCT364PGpFrOQaY+ZQ7qDWqqiT3IMK+AvZ83fo0LvltFn8/UyXvIFc3RO7YcaEjLahAF0otCi8vOq21NtQ==",
+      "dependencies": {
+        "@bergos/jsonparse": "^1.4.0",
+        "@rdfjs/types": "*",
+        "@types/http-link-header": "^1.0.1",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "canonicalize": "^1.0.1",
+        "http-link-header": "^1.0.2",
+        "jsonld-context-parser": "^2.3.0",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0"
+      }
+    },
+    "node_modules/@inrupt/solid-client/node_modules/readable-stream": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@inrupt/universal-fetch": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inrupt/universal-fetch/-/universal-fetch-1.0.3.tgz",
+      "integrity": "sha512-AP/nMOuuKvR2YoQkdS77ntuuq5ZYDGStI8Uirp1MCsyPSoBLyNnRjMLjlGqIlaC+5Xp7TYZJ9z/Kl2uUEpXUFw==",
+      "dependencies": {
+        "node-fetch": "^2.6.7",
+        "undici": "^5.19.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.0.0 || ^18.0.0 || ^20.0.0"
       }
     },
     "node_modules/@inrupt/vocab-common-rdf-rdfdatafactory": {
@@ -1551,6 +1606,57 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz",
+      "integrity": "sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==",
+      "dev": true,
+      "dependencies": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
+    "node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
+      "integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
+      "dev": true,
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.5.0",
+        "webcrypto-core": "^1.7.7"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/@peculiar/webcrypto/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
     },
     "node_modules/@rdfjs/data-model": {
       "version": "1.3.4",
@@ -2122,6 +2228,41 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@web-std/blob": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-3.0.5.tgz",
+      "integrity": "sha512-Lm03qr0eT3PoLBuhkvFBLf0EFkAsNz/G/AYCzpOdi483aFaVX86b4iQs0OHhzHJfN5C15q17UtDbyABjlzM96A==",
+      "dev": true,
+      "dependencies": {
+        "@web-std/stream": "1.0.0",
+        "web-encoding": "1.1.5"
+      }
+    },
+    "node_modules/@web-std/file": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@web-std/file/-/file-3.0.3.tgz",
+      "integrity": "sha512-X7YYyvEERBbaDfJeC9lBKC5Q5lIEWYCP1SNftJNwNH/VbFhdHm+3neKOQP+kWEYJmosbDFq+NEUG7+XIvet/Jw==",
+      "dev": true,
+      "dependencies": {
+        "@web-std/blob": "^3.0.3"
+      }
+    },
+    "node_modules/@web-std/stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@web-std/stream/-/stream-1.0.0.tgz",
+      "integrity": "sha512-jyIbdVl+0ZJyKGTV0Ohb9E6UnxP+t7ZzX4Do3AHjZKxUXKMs9EmqnBDQgHF7bEw0EzbQygOjtt/7gvtmi//iCQ==",
+      "dev": true,
+      "dependencies": {
+        "web-streams-polyfill": "^3.1.1"
+      }
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -2373,6 +2514,26 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
+    "node_modules/asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+      "dev": true,
+      "dependencies": {
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/asn1js/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -2392,6 +2553,18 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/babel-jest": {
       "version": "27.5.1",
@@ -2490,6 +2663,25 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2566,11 +2758,45 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -2870,14 +3096,6 @@
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "dev": true
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/data-urls": {
       "version": "2.0.0",
@@ -3686,14 +3904,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -3932,19 +4142,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-2.1.2.tgz",
-      "integrity": "sha512-YKqtUDwqLyfyMnmbw8XD6Q8j9i/HggKtPEI+pZ1+8bvheBu78biSmNaXWusx1TauGqtUUGx/cBb1mKdq2rLYow==",
-      "engines": {
-        "node": "^10.17.0 || >=12.3.0"
-      },
-      "peerDependenciesMeta": {
-        "domexception": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -4016,6 +4213,15 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
+    },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
     },
     "node_modules/form-data": {
       "version": "3.0.1",
@@ -4120,13 +4326,14 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
       },
       "funding": {
@@ -4236,6 +4443,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -4279,6 +4498,18 @@
       "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4440,6 +4671,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -4533,6 +4783,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-arrayish": {
@@ -4636,6 +4902,21 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -4761,6 +5042,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-typed-array": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
+      "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+      "dev": true,
+      "dependencies": {
+        "which-typed-array": "^1.1.11"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -4811,9 +5107,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -5533,9 +5829,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.10.0.tgz",
-      "integrity": "sha512-KEhB/eLGLomWGPTb+/RNbYsTjIyx03JmbqAyIyiXBuNSa7CmNrJd5ysFhblayzs/e/vbOPMUaLnjHUMhGp4yLw==",
+      "version": "4.14.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.14.5.tgz",
+      "integrity": "sha512-56ns1XlSI8d5V0t7hilPu8dMbE4YIwrTJU6e7bV1Abyu6oel4tSc4YmD742MoWV3U+vn7O0WlKpinzu2DP0HWw==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -5668,27 +5964,13 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/jsonld": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-5.2.0.tgz",
-      "integrity": "sha512-JymgT6Xzk5CHEmHuEyvoTNviEPxv6ihLWSPu1gFdtjSAyM6cFqNrv02yS/SIur3BBIkCf0HjizRc24d8/FfQKw==",
-      "dependencies": {
-        "@digitalbazaar/http-client": "^1.1.0",
-        "canonicalize": "^1.0.1",
-        "lru-cache": "^6.0.0",
-        "rdf-canonize": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/jsonld-context-parser": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.1.5.tgz",
-      "integrity": "sha512-rsu5hB6bADa511l0QhG4lndAqlN7PQ4wsS0UKqLWUKg1GUQqYmh2SNfbwXiRiHZRJqhvCNqv9/5tQ3zzk4hMtg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.3.0.tgz",
+      "integrity": "sha512-c6w2GE57O26eWFjcPX6k6G86ootsIfpuVwhZKjCll0bVoDGBxr1P4OuU+yvgfnh1GJhAGErolfC7W1BklLjWMg==",
       "dependencies": {
         "@types/http-link-header": "^1.0.1",
-        "@types/node": "^13.1.0",
+        "@types/node": "^18.0.0",
         "canonicalize": "^1.0.1",
         "cross-fetch": "^3.0.6",
         "http-link-header": "^1.0.2",
@@ -5697,11 +5979,6 @@
       "bin": {
         "jsonld-context-parse": "bin/jsonld-context-parse.js"
       }
-    },
-    "node_modules/jsonld-context-parser/node_modules/@types/node": {
-      "version": "13.13.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-      "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
     },
     "node_modules/jsonld-streaming-parser": {
       "version": "2.4.3",
@@ -5732,57 +6009,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/ky": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/ky/-/ky-0.25.1.tgz",
-      "integrity": "sha512-PjpCEWlIU7VpiMVrTwssahkYXX1by6NCT0fhTUX34F3DTinARlgMpriuroolugFPcMgpPWrOW4mTb984Qm1RXA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/ky?sponsor=1"
-      }
-    },
-    "node_modules/ky-universal": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.8.2.tgz",
-      "integrity": "sha512-xe0JaOH9QeYxdyGLnzUOVGK4Z6FGvDVzcXFTdrYA1f33MZdEa45sUDaMBy98xQMcsd2XIBrTXRrRYnegcSdgVQ==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "node-fetch": "3.0.0-beta.9"
-      },
-      "engines": {
-        "node": ">=10.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/ky-universal?sponsor=1"
-      },
-      "peerDependencies": {
-        "ky": ">=0.17.0",
-        "web-streams-polyfill": ">=2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "web-streams-polyfill": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ky-universal/node_modules/node-fetch": {
-      "version": "3.0.0-beta.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0-beta.9.tgz",
-      "integrity": "sha512-RdbZCEynH2tH46+tj0ua9caUHVWrd/RHnRfvly2EVdqGmI3ndS1Vn/xjm5KuGejDt2RNDQsVRLPNd2QPwcewVg==",
-      "dependencies": {
-        "data-uri-to-buffer": "^3.0.1",
-        "fetch-blob": "^2.1.1"
-      },
-      "engines": {
-        "node": "^10.17 || >=12.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/leven": {
@@ -5897,9 +6123,9 @@
       }
     },
     "node_modules/license-checker/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -6080,11 +6306,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
-    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -6208,9 +6429,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -6458,9 +6679,9 @@
       }
     },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -6575,9 +6796,9 @@
       }
     },
     "node_modules/oidc-token-hash": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz",
-      "integrity": "sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
+      "integrity": "sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==",
       "engines": {
         "node": "^10.13.0 || >=12.0.0"
       }
@@ -6606,17 +6827,14 @@
       }
     },
     "node_modules/openid-client": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.6.tgz",
-      "integrity": "sha512-HTFaXWdUHvLFw4GaEMgC0jXYBgpjgzQQNHW1pZsSqJorSgrXzxJ+4u/LWCGaClDEse5HLjXRV+zU5Bn3OefiZw==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.4.3.tgz",
+      "integrity": "sha512-sVQOvjsT/sbSfYsQI/9liWQGVZH/Pp3rrtlGEwgk/bbHfrUDZ24DN57lAagIwFtuEu+FM9Ev7r85s8S/yPjimQ==",
       "dependencies": {
-        "jose": "^4.1.4",
+        "jose": "^4.14.4",
         "lru-cache": "^6.0.0",
-        "object-hash": "^2.0.1",
-        "oidc-token-hash": "^5.0.1"
-      },
-      "engines": {
-        "node": "^12.19.0 || ^14.15.0 || ^16.13.0"
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -6923,18 +7141,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
         "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prettier-linter-helpers": {
@@ -6973,6 +7188,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/progress": {
@@ -7036,6 +7259,36 @@
         "url": "https://opencollective.com/fast-check"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
+      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.6.1"
+      }
+    },
+    "node_modules/pvtsutils/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -7054,17 +7307,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/rdf-canonize": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.0.0.tgz",
-      "integrity": "sha512-LXRkhab1QaPJnhUIt1gtXXKswQCZ9zpflsSZFczG7mCLAkMvVjdqCGk9VXCUss0aOUeEyV2jtFxGcdX8DSkj9w==",
-      "dependencies": {
-        "setimmediate": "^1.0.5"
-      },
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/rdf-data-factory": {
       "version": "1.1.0",
@@ -7213,9 +7455,9 @@
       }
     },
     "node_modules/read-installed/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -7337,6 +7579,12 @@
       "engines": {
         "node": ">=0.10.5"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -7544,9 +7792,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -7557,11 +7805,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -7800,6 +8043,14 @@
       "integrity": "sha512-8drZlFIKBHSMdX9GCWv8V9AAWnQcTqw0iAI6/GC7UJ0H0SwKeFKjOoZfGY1tOU00GGU7FYZQoJ/ZCUEoXhD7yQ==",
       "dependencies": {
         "promise-polyfill": "^1.1.6"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/string_decoder": {
@@ -8167,17 +8418,27 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dev": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/tr46": {
@@ -8438,6 +8699,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.23.0.tgz",
+      "integrity": "sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -8480,6 +8752,29 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
       }
     },
     "node_modules/util-deprecate": {
@@ -8576,6 +8871,18 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/web-encoding": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
+      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "dev": true,
+      "dependencies": {
+        "util": "^0.12.3"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "0.9.0"
+      }
+    },
     "node_modules/web-streams-node": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/web-streams-node/-/web-streams-node-0.4.0.tgz",
@@ -8594,10 +8901,38 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/web-streams-ponyfill": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/web-streams-ponyfill/-/web-streams-ponyfill-1.4.2.tgz",
       "integrity": "sha512-LCHW+fE2UBJ2vjhqJujqmoxh1ytEDEr0dPO3CabMdMDJPKmsaxzS90V1Ar6LtNE5VHLqxR4YMEj1i4lzMAccIA=="
+    },
+    "node_modules/webcrypto-core": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
+      "integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
+      "dev": true,
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/webcrypto-core/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
@@ -8668,10 +9003,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
+      "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -8932,9 +9286,9 @@
           }
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -8976,9 +9330,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -9345,6 +9699,14 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@bergos/jsonparse": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@bergos/jsonparse/-/jsonparse-1.4.1.tgz",
+      "integrity": "sha512-vXIT0nzZGX/+yMD5bx2VhTzc92H55tPoehh1BW/FZHOndWGFddrH3MAfdx39FRc7irABirW6EQaGxIJYV6CGuA==",
+      "requires": {
+        "buffer": "^6.0.3"
+      }
+    },
     "@comunica/actor-abstract-mediatyped": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.2.0.tgz",
@@ -9624,16 +9986,6 @@
         }
       }
     },
-    "@digitalbazaar/http-client": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-1.2.0.tgz",
-      "integrity": "sha512-W9KQQ5pUJcaR0I4c2HPJC0a7kRbZApIorZgPnEDwMBgj16iQzutGLrCXYaZOmxqVLVNqqlQ4aUJh+HBQZy4W6Q==",
-      "requires": {
-        "esm": "^3.2.22",
-        "ky": "^0.25.1",
-        "ky-universal": "^0.8.2"
-      }
-    },
     "@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -9681,6 +10033,7 @@
       "resolved": "https://registry.npmjs.org/@inrupt/eslint-config-base/-/eslint-config-base-0.3.0.tgz",
       "integrity": "sha512-wHekhVgAIzoaL5oTXZN99dWws+nxKlbMfhyTsqQzL8hB9q8lC0rfbcKd4B3K0V4zRuhjuicH4YH7LTcJAgUvKA==",
       "dev": true,
+      "peer": true,
       "requires": {}
     },
     "@inrupt/eslint-config-lib": {
@@ -9690,43 +10043,96 @@
       "dev": true,
       "requires": {}
     },
-    "@inrupt/solid-client": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.26.0.tgz",
-      "integrity": "sha512-fiu5z4GHVXgsUlGSWOtxDQBPyQEcXx41Q8JiTem/qJ5oD8OPwJL+mjymJnoMfxyW+jVa5nq4XsF8GnFrF74niQ==",
+    "@inrupt/jest-jsdom-polyfills": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-2.1.3.tgz",
+      "integrity": "sha512-0+yVUdAJ7v5L5JzvqjGdVlDSLdC17yHXStZSNGoXSnUns9OH/Jn3pQFu2IppBMYxyzAbPor7R2geGNtFoqRuig==",
+      "dev": true,
       "requires": {
+        "@peculiar/webcrypto": "^1.4.0",
+        "@web-std/blob": "^3.0.4",
+        "@web-std/file": "^3.0.2",
+        "undici": "^5.23.0"
+      }
+    },
+    "@inrupt/solid-client": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.30.0.tgz",
+      "integrity": "sha512-iRyLqM9k5W0IiRHZz+dGsa+94pu8cGqjRB5B8s+YhLlNQH/fY6Xmu21f1zl1uKWebc4PBlAJPcBcR46RVXlCJQ==",
+      "requires": {
+        "@inrupt/universal-fetch": "^1.0.1",
         "@rdfjs/dataset": "^1.1.0",
         "@types/rdfjs__dataset": "^1.0.4",
-        "cross-fetch": "^3.0.4",
+        "buffer": "^6.0.3",
         "fsevents": "^2.3.2",
         "http-link-header": "^1.1.0",
-        "jsonld": "^5.2.0",
+        "jsonld-context-parser": "^2.3.0",
+        "jsonld-streaming-parser": "^3.2.0",
         "n3": "^1.10.0",
         "uuid": "^9.0.0"
+      },
+      "dependencies": {
+        "jsonld-streaming-parser": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-3.2.0.tgz",
+          "integrity": "sha512-lJR1SCT364PGpFrOQaY+ZQ7qDWqqiT3IMK+AvZ83fo0LvltFn8/UyXvIFc3RO7YcaEjLahAF0otCi8vOq21NtQ==",
+          "requires": {
+            "@bergos/jsonparse": "^1.4.0",
+            "@rdfjs/types": "*",
+            "@types/http-link-header": "^1.0.1",
+            "@types/readable-stream": "^2.3.13",
+            "buffer": "^6.0.3",
+            "canonicalize": "^1.0.1",
+            "http-link-header": "^1.0.2",
+            "jsonld-context-parser": "^2.3.0",
+            "rdf-data-factory": "^1.1.0",
+            "readable-stream": "^4.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+          "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^6.0.3",
+            "events": "^3.3.0",
+            "process": "^0.11.10",
+            "string_decoder": "^1.3.0"
+          }
+        }
       }
     },
     "@inrupt/solid-client-authn-core": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.14.0.tgz",
-      "integrity": "sha512-/H05XiMpgRjhHECT4Pku1jHlQoRzP4H5kcgZH+dbc54mMYrglBuCHXNGgW967zcg0eiCn0NROdovy8r4vl1LWQ==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.17.1.tgz",
+      "integrity": "sha512-UKTtZH0lISgWaiUYRr0zRkvFHIjYzVaWEC0IJoLUFIEfJdYogMXmPKoHyJEw7MdJ6qVYMLdPo9k2OSLfdUfYjA==",
       "requires": {
-        "cross-fetch": "^3.1.5",
+        "@inrupt/universal-fetch": "^1.0.1",
         "events": "^3.3.0",
         "jose": "^4.10.0",
-        "lodash.clonedeep": "^4.5.0",
         "uuid": "^9.0.0"
       }
     },
     "@inrupt/solid-client-authn-node": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.14.0.tgz",
-      "integrity": "sha512-9CPJ9iDBx16ddUR1KxqJIb/fpW2tH6AMb4tCjGB2CgeZXnF+6PR9yeoDlKMMQy0m7GBkj7E5tUadIL3RmQ9pYw==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.17.1.tgz",
+      "integrity": "sha512-4ISQPIz6mIcTLk2sVUEc6q7iD69SuXP50P1A8y8qAAzh/UvFyl2MDwCCXS7+WTpaYKAo2uc54WyYuJhDnu/Ujw==",
       "requires": {
-        "@inrupt/solid-client-authn-core": "^1.14.0",
-        "cross-fetch": "^3.1.5",
+        "@inrupt/solid-client-authn-core": "^1.17.1",
+        "@inrupt/universal-fetch": "^1.0.1",
         "jose": "^4.3.7",
-        "openid-client": "^5.1.0",
+        "openid-client": "~5.4.2",
         "uuid": "^9.0.0"
+      }
+    },
+    "@inrupt/universal-fetch": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inrupt/universal-fetch/-/universal-fetch-1.0.3.tgz",
+      "integrity": "sha512-AP/nMOuuKvR2YoQkdS77ntuuq5ZYDGStI8Uirp1MCsyPSoBLyNnRjMLjlGqIlaC+5Xp7TYZJ9z/Kl2uUEpXUFw==",
+      "requires": {
+        "node-fetch": "^2.6.7",
+        "undici": "^5.19.1"
       }
     },
     "@inrupt/vocab-common-rdf-rdfdatafactory": {
@@ -10094,6 +10500,55 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      }
+    },
+    "@peculiar/asn1-schema": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz",
+      "integrity": "sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==",
+      "dev": true,
+      "requires": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+          "dev": true
+        }
+      }
+    },
+    "@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@peculiar/webcrypto": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
+      "integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
+      "dev": true,
+      "requires": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.5.0",
+        "webcrypto-core": "^1.7.7"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+          "dev": true
+        }
       }
     },
     "@rdfjs/data-model": {
@@ -10533,6 +10988,41 @@
         "eslint-visitor-keys": "^3.3.0"
       }
     },
+    "@web-std/blob": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-3.0.5.tgz",
+      "integrity": "sha512-Lm03qr0eT3PoLBuhkvFBLf0EFkAsNz/G/AYCzpOdi483aFaVX86b4iQs0OHhzHJfN5C15q17UtDbyABjlzM96A==",
+      "dev": true,
+      "requires": {
+        "@web-std/stream": "1.0.0",
+        "web-encoding": "1.1.5"
+      }
+    },
+    "@web-std/file": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@web-std/file/-/file-3.0.3.tgz",
+      "integrity": "sha512-X7YYyvEERBbaDfJeC9lBKC5Q5lIEWYCP1SNftJNwNH/VbFhdHm+3neKOQP+kWEYJmosbDFq+NEUG7+XIvet/Jw==",
+      "dev": true,
+      "requires": {
+        "@web-std/blob": "^3.0.3"
+      }
+    },
+    "@web-std/stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@web-std/stream/-/stream-1.0.0.tgz",
+      "integrity": "sha512-jyIbdVl+0ZJyKGTV0Ohb9E6UnxP+t7ZzX4Do3AHjZKxUXKMs9EmqnBDQgHF7bEw0EzbQygOjtt/7gvtmi//iCQ==",
+      "dev": true,
+      "requires": {
+        "web-streams-polyfill": "^3.1.1"
+      }
+    },
+    "@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "dev": true,
+      "optional": true
+    },
     "abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -10717,6 +11207,25 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
+    "asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+      "dev": true,
+      "requires": {
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+          "dev": true
+        }
+      }
+    },
     "astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -10732,6 +11241,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
     },
     "babel-jest": {
@@ -10810,6 +11325,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -10864,11 +11384,28 @@
         "node-int64": "^0.4.0"
       }
     },
+    "buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
     },
     "call-bind": {
       "version": "1.0.2",
@@ -11107,11 +11644,6 @@
           "dev": true
         }
       }
-    },
-    "data-uri-to-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
     },
     "data-urls": {
       "version": "2.0.0",
@@ -11718,11 +12250,6 @@
       "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "dev": true
     },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
-    },
     "espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -11908,11 +12435,6 @@
         "bser": "2.1.1"
       }
     },
-    "fetch-blob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-2.1.2.tgz",
-      "integrity": "sha512-YKqtUDwqLyfyMnmbw8XD6Q8j9i/HggKtPEI+pZ1+8bvheBu78biSmNaXWusx1TauGqtUUGx/cBb1mKdq2rLYow=="
-    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -11966,6 +12488,15 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
+    },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
     },
     "form-data": {
       "version": "3.0.1",
@@ -12042,13 +12573,14 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
       }
     },
@@ -12119,6 +12651,15 @@
         "slash": "^3.0.0"
       }
     },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -12154,6 +12695,12 @@
       "requires": {
         "get-intrinsic": "^1.1.1"
       }
+    },
+    "has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.3",
@@ -12258,6 +12805,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -12326,6 +12878,16 @@
         "side-channel": "^1.0.4"
       }
     },
+    "is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -12392,6 +12954,15 @@
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
+    },
+    "is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-glob": {
       "version": "4.0.3",
@@ -12471,6 +13042,15 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "is-typed-array": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
+      "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+      "dev": true,
+      "requires": {
+        "which-typed-array": "^1.1.11"
+      }
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -12512,9 +13092,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -13082,9 +13662,9 @@
       }
     },
     "jose": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.10.0.tgz",
-      "integrity": "sha512-KEhB/eLGLomWGPTb+/RNbYsTjIyx03JmbqAyIyiXBuNSa7CmNrJd5ysFhblayzs/e/vbOPMUaLnjHUMhGp4yLw=="
+      "version": "4.14.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.14.5.tgz",
+      "integrity": "sha512-56ns1XlSI8d5V0t7hilPu8dMbE4YIwrTJU6e7bV1Abyu6oel4tSc4YmD742MoWV3U+vn7O0WlKpinzu2DP0HWw=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -13184,35 +13764,17 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "jsonld": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-5.2.0.tgz",
-      "integrity": "sha512-JymgT6Xzk5CHEmHuEyvoTNviEPxv6ihLWSPu1gFdtjSAyM6cFqNrv02yS/SIur3BBIkCf0HjizRc24d8/FfQKw==",
-      "requires": {
-        "@digitalbazaar/http-client": "^1.1.0",
-        "canonicalize": "^1.0.1",
-        "lru-cache": "^6.0.0",
-        "rdf-canonize": "^3.0.0"
-      }
-    },
     "jsonld-context-parser": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.1.5.tgz",
-      "integrity": "sha512-rsu5hB6bADa511l0QhG4lndAqlN7PQ4wsS0UKqLWUKg1GUQqYmh2SNfbwXiRiHZRJqhvCNqv9/5tQ3zzk4hMtg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.3.0.tgz",
+      "integrity": "sha512-c6w2GE57O26eWFjcPX6k6G86ootsIfpuVwhZKjCll0bVoDGBxr1P4OuU+yvgfnh1GJhAGErolfC7W1BklLjWMg==",
       "requires": {
         "@types/http-link-header": "^1.0.1",
-        "@types/node": "^13.1.0",
+        "@types/node": "^18.0.0",
         "canonicalize": "^1.0.1",
         "cross-fetch": "^3.0.6",
         "http-link-header": "^1.0.2",
         "relative-to-absolute-iri": "^1.0.5"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "13.13.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-          "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
-        }
       }
     },
     "jsonld-streaming-parser": {
@@ -13239,31 +13801,6 @@
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
       "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
       "dev": true
-    },
-    "ky": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/ky/-/ky-0.25.1.tgz",
-      "integrity": "sha512-PjpCEWlIU7VpiMVrTwssahkYXX1by6NCT0fhTUX34F3DTinARlgMpriuroolugFPcMgpPWrOW4mTb984Qm1RXA=="
-    },
-    "ky-universal": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.8.2.tgz",
-      "integrity": "sha512-xe0JaOH9QeYxdyGLnzUOVGK4Z6FGvDVzcXFTdrYA1f33MZdEa45sUDaMBy98xQMcsd2XIBrTXRrRYnegcSdgVQ==",
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "node-fetch": "3.0.0-beta.9"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "3.0.0-beta.9",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0-beta.9.tgz",
-          "integrity": "sha512-RdbZCEynH2tH46+tj0ua9caUHVWrd/RHnRfvly2EVdqGmI3ndS1Vn/xjm5KuGejDt2RNDQsVRLPNd2QPwcewVg==",
-          "requires": {
-            "data-uri-to-buffer": "^3.0.1",
-            "fetch-blob": "^2.1.1"
-          }
-        }
-      }
     },
     "leven": {
       "version": "3.1.0",
@@ -13356,9 +13893,9 @@
           "dev": true
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         },
         "supports-color": {
@@ -13492,11 +14029,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -13592,9 +14124,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -13797,9 +14329,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         }
       }
@@ -13883,9 +14415,9 @@
       }
     },
     "oidc-token-hash": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz",
-      "integrity": "sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ=="
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
+      "integrity": "sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw=="
     },
     "once": {
       "version": "1.4.0",
@@ -13905,14 +14437,14 @@
       }
     },
     "openid-client": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.1.6.tgz",
-      "integrity": "sha512-HTFaXWdUHvLFw4GaEMgC0jXYBgpjgzQQNHW1pZsSqJorSgrXzxJ+4u/LWCGaClDEse5HLjXRV+zU5Bn3OefiZw==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.4.3.tgz",
+      "integrity": "sha512-sVQOvjsT/sbSfYsQI/9liWQGVZH/Pp3rrtlGEwgk/bbHfrUDZ24DN57lAagIwFtuEu+FM9Ev7r85s8S/yPjimQ==",
       "requires": {
-        "jose": "^4.1.4",
+        "jose": "^4.14.4",
         "lru-cache": "^6.0.0",
-        "object-hash": "^2.0.1",
-        "oidc-token-hash": "^5.0.1"
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
       }
     },
     "optionator": {
@@ -14131,9 +14663,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -14163,6 +14695,11 @@
           "dev": true
         }
       }
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "progress": {
       "version": "2.0.3",
@@ -14211,18 +14748,39 @@
       "integrity": "sha512-ksWccjmXOHU2gJBnH0cK1lSYdvSZ0zLoCMSz/nTGh6hDvCSgcRxDyIcOBD6KNxFz3xhMPm/T267Tbe2JRymKEQ==",
       "dev": true
     },
+    "pvtsutils": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
+      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.6.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+          "dev": true
+        }
+      }
+    },
+    "pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "dev": true
+    },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
-    },
-    "rdf-canonize": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.0.0.tgz",
-      "integrity": "sha512-LXRkhab1QaPJnhUIt1gtXXKswQCZ9zpflsSZFczG7mCLAkMvVjdqCGk9VXCUss0aOUeEyV2jtFxGcdX8DSkj9w==",
-      "requires": {
-        "setimmediate": "^1.0.5"
-      }
     },
     "rdf-data-factory": {
       "version": "1.1.0",
@@ -14361,9 +14919,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         }
       }
@@ -14452,6 +15010,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
       "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+      "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
     },
     "resolve": {
@@ -14603,18 +15167,13 @@
       }
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -14813,6 +15372,11 @@
       "requires": {
         "promise-polyfill": "^1.1.6"
       }
+    },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -15080,14 +15644,23 @@
       }
     },
     "tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dev": true,
       "requires": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+          "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+          "dev": true
+        }
       }
     },
     "tr46": {
@@ -15256,6 +15829,14 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
+    "undici": {
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.23.0.tgz",
+      "integrity": "sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==",
+      "requires": {
+        "busboy": "^1.6.0"
+      }
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -15279,6 +15860,29 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
       }
     },
     "util-deprecate": {
@@ -15365,6 +15969,16 @@
         "makeerror": "1.0.12"
       }
     },
+    "web-encoding": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
+      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "dev": true,
+      "requires": {
+        "@zxing/text-encoding": "0.9.0",
+        "util": "^0.12.3"
+      }
+    },
     "web-streams-node": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/web-streams-node/-/web-streams-node-0.4.0.tgz",
@@ -15382,10 +15996,37 @@
         }
       }
     },
+    "web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "dev": true
+    },
     "web-streams-ponyfill": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/web-streams-ponyfill/-/web-streams-ponyfill-1.4.2.tgz",
       "integrity": "sha512-LCHW+fE2UBJ2vjhqJujqmoxh1ytEDEr0dPO3CabMdMDJPKmsaxzS90V1Ar6LtNE5VHLqxR4YMEj1i4lzMAccIA=="
+    },
+    "webcrypto-core": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
+      "integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
+      "dev": true,
+      "requires": {
+        "@peculiar/asn1-schema": "^2.3.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+          "dev": true
+        }
+      }
     },
     "webidl-conversions": {
       "version": "6.1.0",
@@ -15441,10 +16082,23 @@
         "is-symbol": "^1.0.3"
       }
     },
+    "which-typed-array": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
+      "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
     "wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
-        "@inrupt/solid-client": "1.23.3",
-        "@inrupt/solid-client-authn-node": "1.12.2",
+        "@inrupt/solid-client": "1.26.0",
+        "@inrupt/solid-client-authn-node": "1.14.0",
         "@inrupt/vocab-common-rdf-rdfdatafactory": "1.0.3",
         "@inrupt/vocab-etl-tutorial-bundle-all-rdfdatafactory": "file:./src/InruptTooling/Vocab/EtlTutorial/Generated/SourceCodeArtifacts/TypeScript-RdfDataFactory",
         "@inrupt/vocab-inrupt-core-rdfdatafactory": "1.0.3",
@@ -1045,62 +1045,53 @@
       }
     },
     "node_modules/@inrupt/solid-client": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.23.3.tgz",
-      "integrity": "sha512-+qzlqtXkM1V2wdZcIWpq6mS+NAfJIeAyWghQBHHLz1hmHiKaE+H0UljOt2B4oSrRYuQq/PYvD/a6N4vfMU+vWg==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.26.0.tgz",
+      "integrity": "sha512-fiu5z4GHVXgsUlGSWOtxDQBPyQEcXx41Q8JiTem/qJ5oD8OPwJL+mjymJnoMfxyW+jVa5nq4XsF8GnFrF74niQ==",
       "dependencies": {
         "@rdfjs/dataset": "^1.1.0",
-        "@rdfjs/types": "^1.1.0",
-        "@types/n3": "^1.10.0",
         "@types/rdfjs__dataset": "^1.0.4",
         "cross-fetch": "^3.0.4",
-        "http-link-header": "^1.0.2",
+        "http-link-header": "^1.1.0",
         "jsonld": "^5.2.0",
-        "n3": "^1.10.0"
+        "n3": "^1.10.0",
+        "uuid": "^9.0.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
       }
     },
     "node_modules/@inrupt/solid-client-authn-core": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.12.2.tgz",
-      "integrity": "sha512-UitzMHfUKVHy5ogYgdRLo82CUkHrFLJfnYH8jxpELEK+EzOg3zDT0vmNyNjpZ9vL9th9BOzy8RBuwWusZuo/wg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.14.0.tgz",
+      "integrity": "sha512-/H05XiMpgRjhHECT4Pku1jHlQoRzP4H5kcgZH+dbc54mMYrglBuCHXNGgW967zcg0eiCn0NROdovy8r4vl1LWQ==",
       "dependencies": {
-        "@inrupt/solid-common-vocab": "^1.0.0",
-        "@types/lodash.clonedeep": "^4.5.6",
-        "@types/uuid": "^8.3.0",
         "cross-fetch": "^3.1.5",
         "events": "^3.3.0",
-        "jose": "^4.3.7",
+        "jose": "^4.10.0",
         "lodash.clonedeep": "^4.5.0",
-        "uuid": "^8.3.1"
+        "uuid": "^9.0.0"
       },
       "engines": {
         "node": "^14.0.0 || ^16.0.0"
       }
     },
     "node_modules/@inrupt/solid-client-authn-node": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.12.2.tgz",
-      "integrity": "sha512-w7RLSMz87gJ+5xUFoH/XfKTC05kipJr5kjfJdezKrGr1RhrbLu1byPWn5iW+tfANuWtvlsXIHhEJxG7YW1Q2bQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.14.0.tgz",
+      "integrity": "sha512-9CPJ9iDBx16ddUR1KxqJIb/fpW2tH6AMb4tCjGB2CgeZXnF+6PR9yeoDlKMMQy0m7GBkj7E5tUadIL3RmQ9pYw==",
       "dependencies": {
-        "@inrupt/solid-client-authn-core": "^1.12.2",
+        "@inrupt/solid-client-authn-core": "^1.14.0",
         "cross-fetch": "^3.1.5",
         "jose": "^4.3.7",
         "openid-client": "^5.1.0",
-        "uuid": "^8.3.2"
+        "uuid": "^9.0.0"
       },
       "engines": {
         "node": "^14.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@inrupt/solid-common-vocab": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-common-vocab/-/solid-common-vocab-1.0.1.tgz",
-      "integrity": "sha512-daCb8amQHzfB9N5bop3enur6l6UHjt9/fxvC8Or9wdzybAGMSF7UcrW3Pr/MM5H0GOKrVBczlxR4t6sMWgul1g==",
-      "dependencies": {
-        "@rdfjs/types": "^1.1.0"
       }
     },
     "node_modules/@inrupt/vocab-common-rdf-rdfdatafactory": {
@@ -1797,19 +1788,6 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
-    "node_modules/@types/lodash": {
-      "version": "4.14.186",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
-      "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw=="
-    },
-    "node_modules/@types/lodash.clonedeep": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
-      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -1872,11 +1850,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
@@ -4390,9 +4363,9 @@
       }
     },
     "node_modules/http-link-header": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.0.4.tgz",
-      "integrity": "sha512-Cnv3Q+FF+35avekdnH/ML8dls++tdnSgrvUIWw0YEszrWeLSuw5Iq1vyCVTb5v0rEUgFTy0x4shxXyrO0MDUzw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.0.tgz",
+      "integrity": "sha512-pj6N1yxOz/ANO8HHsWGg/OoIL1kmRYvQnXQ7PIRpgp+15AnEsRH8fmIJE6D1OdWG2Bov+BJHVla1fFXxg1JbbA==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -8441,6 +8414,7 @@
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8520,9 +8494,9 @@
       "dev": true
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -8888,10 +8862,13 @@
     },
     "src/InruptTooling/Vocab/EtlTutorial/Generated/SourceCodeArtifacts/TypeScript-RdfDataFactory": {
       "name": "@inrupt/vocab-etl-tutorial-bundle-all-rdfdatafactory",
-      "version": "0.0.1",
+      "version": "1.0.1",
+      "license": "Proprietary",
       "dependencies": {
         "@rdfjs/types": "^1.0.1",
-        "rdf-data-factory": "^1.1.0",
+        "rdf-data-factory": "^1.1.0"
+      },
+      "devDependencies": {
         "typescript": "^4.7.4"
       }
     }
@@ -9714,53 +9691,42 @@
       "requires": {}
     },
     "@inrupt/solid-client": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.23.3.tgz",
-      "integrity": "sha512-+qzlqtXkM1V2wdZcIWpq6mS+NAfJIeAyWghQBHHLz1hmHiKaE+H0UljOt2B4oSrRYuQq/PYvD/a6N4vfMU+vWg==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.26.0.tgz",
+      "integrity": "sha512-fiu5z4GHVXgsUlGSWOtxDQBPyQEcXx41Q8JiTem/qJ5oD8OPwJL+mjymJnoMfxyW+jVa5nq4XsF8GnFrF74niQ==",
       "requires": {
         "@rdfjs/dataset": "^1.1.0",
-        "@rdfjs/types": "^1.1.0",
-        "@types/n3": "^1.10.0",
         "@types/rdfjs__dataset": "^1.0.4",
         "cross-fetch": "^3.0.4",
-        "http-link-header": "^1.0.2",
+        "fsevents": "^2.3.2",
+        "http-link-header": "^1.1.0",
         "jsonld": "^5.2.0",
-        "n3": "^1.10.0"
+        "n3": "^1.10.0",
+        "uuid": "^9.0.0"
       }
     },
     "@inrupt/solid-client-authn-core": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.12.2.tgz",
-      "integrity": "sha512-UitzMHfUKVHy5ogYgdRLo82CUkHrFLJfnYH8jxpELEK+EzOg3zDT0vmNyNjpZ9vL9th9BOzy8RBuwWusZuo/wg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.14.0.tgz",
+      "integrity": "sha512-/H05XiMpgRjhHECT4Pku1jHlQoRzP4H5kcgZH+dbc54mMYrglBuCHXNGgW967zcg0eiCn0NROdovy8r4vl1LWQ==",
       "requires": {
-        "@inrupt/solid-common-vocab": "^1.0.0",
-        "@types/lodash.clonedeep": "^4.5.6",
-        "@types/uuid": "^8.3.0",
         "cross-fetch": "^3.1.5",
         "events": "^3.3.0",
-        "jose": "^4.3.7",
+        "jose": "^4.10.0",
         "lodash.clonedeep": "^4.5.0",
-        "uuid": "^8.3.1"
+        "uuid": "^9.0.0"
       }
     },
     "@inrupt/solid-client-authn-node": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.12.2.tgz",
-      "integrity": "sha512-w7RLSMz87gJ+5xUFoH/XfKTC05kipJr5kjfJdezKrGr1RhrbLu1byPWn5iW+tfANuWtvlsXIHhEJxG7YW1Q2bQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.14.0.tgz",
+      "integrity": "sha512-9CPJ9iDBx16ddUR1KxqJIb/fpW2tH6AMb4tCjGB2CgeZXnF+6PR9yeoDlKMMQy0m7GBkj7E5tUadIL3RmQ9pYw==",
       "requires": {
-        "@inrupt/solid-client-authn-core": "^1.12.2",
+        "@inrupt/solid-client-authn-core": "^1.14.0",
         "cross-fetch": "^3.1.5",
         "jose": "^4.3.7",
         "openid-client": "^5.1.0",
-        "uuid": "^8.3.2"
-      }
-    },
-    "@inrupt/solid-common-vocab": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-common-vocab/-/solid-common-vocab-1.0.1.tgz",
-      "integrity": "sha512-daCb8amQHzfB9N5bop3enur6l6UHjt9/fxvC8Or9wdzybAGMSF7UcrW3Pr/MM5H0GOKrVBczlxR4t6sMWgul1g==",
-      "requires": {
-        "@rdfjs/types": "^1.1.0"
+        "uuid": "^9.0.0"
       }
     },
     "@inrupt/vocab-common-rdf-rdfdatafactory": {
@@ -10351,19 +10317,6 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
-    "@types/lodash": {
-      "version": "4.14.186",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
-      "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw=="
-    },
-    "@types/lodash.clonedeep": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
-      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -10426,11 +10379,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
-    },
-    "@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "@types/yargs": {
       "version": "16.0.4",
@@ -12264,9 +12212,9 @@
       }
     },
     "http-link-header": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.0.4.tgz",
-      "integrity": "sha512-Cnv3Q+FF+35avekdnH/ML8dls++tdnSgrvUIWw0YEszrWeLSuw5Iq1vyCVTb5v0rEUgFTy0x4shxXyrO0MDUzw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.0.tgz",
+      "integrity": "sha512-pj6N1yxOz/ANO8HHsWGg/OoIL1kmRYvQnXQ7PIRpgp+15AnEsRH8fmIJE6D1OdWG2Bov+BJHVla1fFXxg1JbbA=="
     },
     "http-proxy-agent": {
       "version": "4.0.1",
@@ -15293,7 +15241,8 @@
     "typescript": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.2",
@@ -15344,9 +15293,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.9.0",
   "license": "MIT",
   "scripts": {
-    "build": "rollup --config rollup.config.js",
+    "build": "rollup --config rollup.config.js --bundleConfigAsCjs",
     "lint": "eslint src",
     "test": "jest src",
     "test-all": "npm test && npm run e2e-test-node-ExtractTransform-display && npm run e2e-test-node-localExtract-TransformLoad",
@@ -72,8 +72,8 @@
     "license-checker": "^25.0.1",
     "lint-staged": "^12.3.2",
     "prettier": "2.5.1",
-    "rollup": "^2.66.1",
-    "rollup-plugin-typescript2": "^0.30.0",
+    "rollup": "^3.28.1",
+    "rollup-plugin-typescript2": "^0.35.0",
     "ts-jest": "^27.1.3",
     "ts-node": "^10.8.1",
     "typescript": "^4.6.2"

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "url": "https://github.com/inrupt/etl-tutorial.git"
   },
   "devDependencies": {
-    "@inrupt/eslint-config-base": "^0.3.0",
     "@inrupt/eslint-config-lib": "^0.3.0",
+    "@inrupt/jest-jsdom-polyfills": "^2.1.3",
     "@inrupt/vocab-inrupt-test-rdfdatafactory": "^1.0.3",
     "@skypack/package-check": "^0.2.2",
     "@types/debug": "^4.1.7",
@@ -71,7 +71,7 @@
     "jest": "^27.4.7",
     "license-checker": "^25.0.1",
     "lint-staged": "^12.3.2",
-    "prettier": "^2.5.1",
+    "prettier": "2.5.1",
     "rollup": "^2.66.1",
     "rollup-plugin-typescript2": "^0.30.0",
     "ts-jest": "^27.1.3",
@@ -83,14 +83,13 @@
     "*.{ts,tsx,js,jsx,css,md,mdx}": "prettier --write"
   },
   "dependencies": {
-    "@inrupt/solid-client": "1.26.0",
-    "@inrupt/solid-client-authn-node": "1.14.0",
+    "@inrupt/solid-client": "^1.30.0",
+    "@inrupt/solid-client-authn-node": "^1.17.1",
     "@inrupt/vocab-common-rdf-rdfdatafactory": "1.0.3",
     "@inrupt/vocab-etl-tutorial-bundle-all-rdfdatafactory": "file:./src/InruptTooling/Vocab/EtlTutorial/Generated/SourceCodeArtifacts/TypeScript-RdfDataFactory",
     "@inrupt/vocab-inrupt-core-rdfdatafactory": "1.0.3",
     "@rdfjs/dataset": "^1.1.1",
     "@rdfjs/types": "^1.0.1",
-    "cross-fetch": "^3.1.4",
     "debug": "^4.3.3",
     "glob": "^7.2.0",
     "rdf-data-factory": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -83,8 +83,8 @@
     "*.{ts,tsx,js,jsx,css,md,mdx}": "prettier --write"
   },
   "dependencies": {
-    "@inrupt/solid-client": "1.23.3",
-    "@inrupt/solid-client-authn-node": "1.12.2",
+    "@inrupt/solid-client": "1.26.0",
+    "@inrupt/solid-client-authn-node": "1.14.0",
     "@inrupt/vocab-common-rdf-rdfdatafactory": "1.0.3",
     "@inrupt/vocab-etl-tutorial-bundle-all-rdfdatafactory": "file:./src/InruptTooling/Vocab/EtlTutorial/Generated/SourceCodeArtifacts/TypeScript-RdfDataFactory",
     "@inrupt/vocab-inrupt-core-rdfdatafactory": "1.0.3",

--- a/resources/Vocab/EtlTutorial/Extension/inrupt-common-TEMP_COPY.ttl
+++ b/resources/Vocab/EtlTutorial/Extension/inrupt-common-TEMP_COPY.ttl
@@ -48,7 +48,7 @@ inrupt_common:acronym rdfs:subPropertyOf skosxl:labelRelation ;
     schema:domainIncludes skosxl:Label ;
     schema:rangeIncludes skosxl:Label .
 
-inrupt_common:acronymExpandedForm a rdfs:Property ;
+inrupt_common:acronymExpandedForm a rdf:Property ;
     rdfs:isDefinedBy inrupt_common: ;
     rdfs:label "Acronym expanded form"@en ;
     rdfs:label "Forma expandida de siglas"@es ;

--- a/resources/Vocab/EtlTutorial/Extension/inrupt-common-TEMP_COPY.ttl
+++ b/resources/Vocab/EtlTutorial/Extension/inrupt-common-TEMP_COPY.ttl
@@ -7,7 +7,7 @@ prefix dcterms:  <http://purl.org/dc/terms/>
 prefix skos:     <http://www.w3.org/2004/02/skos/core#>
 prefix skosxl:   <http://www.w3.org/2008/05/skos-xl#>
 prefix cc:       <http://creativecommons.org/ns#>
-prefix schema:   <http://schema.org/>
+prefix schema:   <https://schema.org/>
 
 prefix inrupt_gen:    <https://inrupt.com/vocab/tool/artifact_generator#>
 prefix inrupt_common: <https://inrupt.com/vocab/common#>

--- a/resources/Vocab/EtlTutorial/Extension/solid-etl-tutorial-ext.ttl
+++ b/resources/Vocab/EtlTutorial/Extension/solid-etl-tutorial-ext.ttl
@@ -3,7 +3,7 @@ prefix rdfs:     <http://www.w3.org/2000/01/rdf-schema#>
 prefix xsd:      <http://www.w3.org/2001/XMLSchema#>
 prefix owl:      <http://www.w3.org/2002/07/owl#>
 prefix dcterms:  <http://purl.org/dc/terms/>
-prefix schema:   <http://schema.org/>
+prefix schema:   <https://schema.org/>
 prefix vann:     <http://purl.org/vocab/vann/>
 prefix dalicc:   <http://dalicc.net/licenselibrary/>
 

--- a/resources/Vocab/Hobby/CopyOfVocab/PetRock.ttl
+++ b/resources/Vocab/Hobby/CopyOfVocab/PetRock.ttl
@@ -3,7 +3,7 @@ prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 prefix owl: <http://www.w3.org/2002/07/owl#>
 prefix vann: <http://purl.org/vocab/vann/>
 prefix dcterms: <http://purl.org/dc/terms/>
-prefix schema: <http://schema.org/>
+prefix schema: <https://schema.org/>
 prefix dalicc: <http://dalicc.net/licenselibrary/>
 
 prefix inrupt_gen: <https://inrupt.com/vocab/tool/artifact_generator#>

--- a/resources/Vocab/ThirdParty/CopyOfVocab/inrupt-3rd-party-companies-house-uk.ttl
+++ b/resources/Vocab/ThirdParty/CopyOfVocab/inrupt-3rd-party-companies-house-uk.ttl
@@ -7,7 +7,7 @@ prefix dcterms: <http://purl.org/dc/terms/>
 prefix cc: <http://creativecommons.org/ns#>
 prefix skos: <http://www.w3.org/2004/02/skos/core#>
 prefix skosxl: <http://www.w3.org/2008/05/skos-xl#>
-prefix schema: <http://schema.org/>
+prefix schema: <https://schema.org/>
 
 prefix inrupt_gen: <https://inrupt.com/vocab/tool/artifact_generator#>
 prefix inrupt_common: <https://inrupt.com/vocab/common#>

--- a/resources/test/PodPat-AsTurtle.ttl
+++ b/resources/test/PodPat-AsTurtle.ttl
@@ -23,7 +23,7 @@ prefix ws:         <http://www.w3.org/ns/pim/space#>
 prefix ldp:        <http://www.w3.org/ns/ldp#>
 prefix dbpedia:    <http://dbpedia.org/resource/>
 prefix httph:      <http://www.w3.org/2007/ont/httph#>
-prefix schema:     <http://schema.org/>
+prefix schema:     <https://schema.org/>
 prefix odrl:       <http://www.w3.org/ns/odrl/2/>
 prefix dpv:        <http://www.w3.org/ns/dpv#>
 prefix gconsent:   <https://w3id.org/GConsent#>

--- a/resources/test/PodPat.trig
+++ b/resources/test/PodPat.trig
@@ -23,7 +23,7 @@ prefix ws:         <http://www.w3.org/ns/pim/space#>
 prefix ldp:        <http://www.w3.org/ns/ldp#>
 prefix dbpedia:    <http://dbpedia.org/resource/>
 prefix httph:      <http://www.w3.org/2007/ont/httph#>
-prefix schema:     <http://schema.org/>
+prefix schema:     <https://schema.org/>
 prefix odrl:       <http://www.w3.org/ns/odrl/2/>
 prefix dpv:        <http://www.w3.org/ns/dpv#>
 prefix gconsent:   <https://w3id.org/GConsent#>

--- a/src/commandLineProcessor.ts
+++ b/src/commandLineProcessor.ts
@@ -79,14 +79,7 @@ export default async function processCommandLine<T>(
   // TODO: This is a kinda ridiculous 'fix', but using the return type from `yargs.parse()` fails,
   //  so just using the actual return type as described by the TS error.
   // ): { [key in keyof Arguments<T>]: Arguments<T>[key] } {
-): Promise<{
-  [x: string]: unknown;
-  localUserCredentialResourceGlob: unknown;
-  outputDirectory: string;
-  quiet: boolean;
-  _: (string | number)[];
-  $0: string;
-}> {
+) {
   return (
     yargs
       .exitProcess(exitOnFail)

--- a/src/commandLineProcessor.ts
+++ b/src/commandLineProcessor.ts
@@ -76,9 +76,6 @@ function configureLog(argv: Arguments) {
 export default async function processCommandLine<T>(
   exitOnFail: boolean,
   commandLineArgs: string | ReadonlyArray<string>
-  // TODO: This is a kinda ridiculous 'fix', but using the return type from `yargs.parse()` fails,
-  //  so just using the actual return type as described by the TS error.
-  // ): { [key in keyof Arguments<T>]: Arguments<T>[key] } {
 ) {
   return (
     yargs

--- a/src/dataSource/clientCompaniesHouseUk.test.ts
+++ b/src/dataSource/clientCompaniesHouseUk.test.ts
@@ -19,9 +19,10 @@
 
 import { SolidDataset } from "@inrupt/solid-client";
 
-import { fetch as crossFetch } from "cross-fetch";
 import { config } from "dotenv-flow";
-import { SCHEMA_INRUPT } from "@inrupt/vocab-common-rdf-rdfdatafactory";
+// import { SCHEMA_INRUPT } from "@inrupt/vocab-common-rdf-rdfdatafactory";
+import { DataFactory } from "rdf-data-factory";
+import * as RDFJS from "rdf-js";
 import { createCredentialResourceFromEnvironmentVariables } from "../credentialUtil";
 import {
   getStringNoLocaleMandatoryOne,
@@ -32,14 +33,14 @@ import {
 /* eslint-disable import/extensions */
 import companiesHouseUkSearchCompanyIdExample from "../../resources/test/RealData/PublicApiResponse/api-uk-companieshouse-search-companyid-unilever.json";
 
-/* eslint-enable import/extensions */
 import {
   companiesHouseUkExtractCompanyById,
   companiesHouseUkTransformCompany,
 } from "./clientCompaniesHouseUk";
 
-jest.mock("cross-fetch");
-const mockedFetch = crossFetch as jest.MockedFunction<typeof crossFetch>;
+const factory: RDFJS.DataFactory = new DataFactory();
+
+const mockedFetch = jest.spyOn(global, "fetch");
 
 // Load environment variables from .env.test.local if available:
 config({
@@ -110,13 +111,15 @@ describe("Companies House UK data source", () => {
 
       const addressResource = getThingOfTypeFromCollectionMandatoryOne(
         resourceDetails,
-        SCHEMA_INRUPT.PostalAddress
+        // SCHEMA_INRUPT.PostalAddress
+        factory.namedNode("https://schema.org/PostalAddress")
       );
 
       expect(
         getStringNoLocaleMandatoryOne(
           addressResource,
-          SCHEMA_INRUPT.addressRegion
+          // SCHEMA_INRUPT.addressRegion
+          factory.namedNode("https://schema.org/addressRegion")
         )
       ).toEqual("Wirral");
     });

--- a/src/dataSource/clientCompaniesHouseUk.ts
+++ b/src/dataSource/clientCompaniesHouseUk.ts
@@ -18,7 +18,6 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import debugModule from "debug";
-import { fetch as crossFetch } from "cross-fetch";
 import { RDF, RDFS } from "@inrupt/vocab-common-rdf-rdfdatafactory";
 import {
   INRUPT_COMMON,
@@ -83,7 +82,7 @@ export async function companiesHouseUkExtractCompanyById(
     companyId
   );
 
-  return crossFetch(endpoint, {
+  return fetch(endpoint, {
     method: "GET",
     headers: {
       Accept: "application/json",

--- a/src/dataSource/clientCompaniesHouseUk.ts
+++ b/src/dataSource/clientCompaniesHouseUk.ts
@@ -19,11 +19,7 @@
 
 import debugModule from "debug";
 import { fetch as crossFetch } from "cross-fetch";
-import {
-  RDF,
-  RDFS,
-  SCHEMA_INRUPT,
-} from "@inrupt/vocab-common-rdf-rdfdatafactory";
+import { RDF, RDFS } from "@inrupt/vocab-common-rdf-rdfdatafactory";
 import {
   INRUPT_COMMON,
   INRUPT_3RD_PARTY_COMPANIES_HOUSE_UK,
@@ -165,25 +161,25 @@ export function companiesHouseUkTransformCompany(
     const address = buildThing({
       url: `${searchResultIri}address`,
     })
-      .addIri(RDF.type, SCHEMA_INRUPT.PostalAddress)
+      .addIri(RDF.type, "https://schema.org/PostalAddress")
       .addStringEnglish(RDFS.label, "Address")
       .addStringNoLocale(
-        SCHEMA_INRUPT.streetAddress,
+        "https://schema.org/streetAddress",
         companyDataAsJson.address_snippet
       )
       .addStringNoLocale(
-        SCHEMA_INRUPT.addressLocality,
+        "https://schema.org/addressLocality",
         companyDataAsJson.address.locality
       )
       .addStringNoLocale(
-        SCHEMA_INRUPT.addressRegion,
+        "https://schema.org/addressRegion",
         companyDataAsJson.address.address_line_1
       )
       .addStringNoLocale(
-        SCHEMA_INRUPT.postalCode,
+        "https://schema.org/postalCode",
         companyDataAsJson.address.postal_code
       )
-      .addStringNoLocale(SCHEMA_INRUPT.addressCountry, countryValue)
+      .addStringNoLocale("https://schema.org/addressCountry", countryValue)
       .build();
 
     const company = buildDataset(
@@ -192,18 +188,18 @@ export function companiesHouseUkTransformCompany(
       })
         // Here we are saying that we consider this company to be of type
         // 'Schema.org Organization' (i.e., literally of type
-        // 'http://schema.org/Organization').
-        .addIri(RDF.type, SCHEMA_INRUPT.NS("Organization"))
+        // 'https://schema.org/Organization').
+        .addIri(RDF.type, "https://schema.org/Organization")
         // Link our company to its address.
-        .addIri(SCHEMA_INRUPT.address, address.url)
+        .addIri("https://schema.org/address", address.url)
 
-        .addStringNoLocale(SCHEMA_INRUPT.name, companyDataAsJson.title)
+        .addStringNoLocale("https://schema.org/name", companyDataAsJson.title)
         .addStringNoLocale(
           INRUPT_3RD_PARTY_COMPANIES_HOUSE_UK.status,
           companyDataAsJson.company_status
         )
         .addDate(
-          SCHEMA_INRUPT.startDate,
+          "https://schema.org/startDate",
           new Date(companyDataAsJson.date_of_creation)
         )
         .build()

--- a/src/dataSource/clientHobbyFile.ts
+++ b/src/dataSource/clientHobbyFile.ts
@@ -19,7 +19,7 @@
 
 import debugModule from "debug";
 import fs from "fs";
-import { RDF, SCHEMA_INRUPT } from "@inrupt/vocab-common-rdf-rdfdatafactory";
+import { RDF } from "@inrupt/vocab-common-rdf-rdfdatafactory";
 import { HOBBY } from "@inrupt/vocab-etl-tutorial-bundle-all-rdfdatafactory";
 import { buildThing, SolidDataset } from "@inrupt/solid-client";
 import { APPLICATION_NAME } from "../applicationConstant";
@@ -102,15 +102,21 @@ export function hobbyTransform(
     url: `${hobbyIri}address`,
   })
     // Denote the type of this resource.
-    .addIri(RDF.type, SCHEMA_INRUPT.PostalAddress)
-    .addStringNoLocale(SCHEMA_INRUPT.streetAddress, addressComponents[0].trim())
+    .addIri(RDF.type, "https://schema.org/PostalAddress")
     .addStringNoLocale(
-      SCHEMA_INRUPT.addressLocality,
+      "https://schema.org/streetAddress",
+      addressComponents[0].trim()
+    )
+    .addStringNoLocale(
+      "https://schema.org/addressLocality",
       addressComponents[1].trim()
     )
-    .addStringNoLocale(SCHEMA_INRUPT.addressRegion, addressComponents[2].trim())
     .addStringNoLocale(
-      SCHEMA_INRUPT.addressCountry,
+      "https://schema.org/addressRegion",
+      addressComponents[2].trim()
+    )
+    .addStringNoLocale(
+      "https://schema.org/addressCountry",
       addressComponents[3].trim()
     )
     .build();
@@ -120,10 +126,10 @@ export function hobbyTransform(
   })
     // Denote the type of this resource.
     .addIri(RDF.type, HOBBY.Hobby)
-    .addStringEnglish(SCHEMA_INRUPT.name, hobbyDataAsJson.club)
+    .addStringEnglish("https://schema.org/name", hobbyDataAsJson.club)
     .addStringNoLocale(HOBBY.kind, hobbyDataAsJson.kind_of_hobby)
-    .addIri(SCHEMA_INRUPT.NS("member"), hobbyDataAsJson.web_site)
-    .addIri(SCHEMA_INRUPT.address, hobbyAddress)
+    .addIri("https://schema.org/member", hobbyDataAsJson.web_site)
+    .addIri("https://schema.org/address", hobbyAddress)
     .build();
 
   result.rdfResources.push(buildDataset(hobbyAddress));

--- a/src/dataSource/clientPassportInMemory.ts
+++ b/src/dataSource/clientPassportInMemory.ts
@@ -38,12 +38,7 @@
 import { Blob } from "node:buffer";
 import fs from "fs";
 import debugModule from "debug";
-import {
-  RDF,
-  SCHEMA_INRUPT,
-  CRED,
-  RDFS,
-} from "@inrupt/vocab-common-rdf-rdfdatafactory";
+import { RDF, CRED, RDFS } from "@inrupt/vocab-common-rdf-rdfdatafactory";
 import {
   DPV_PD,
   GIST,
@@ -81,6 +76,7 @@ const inputToEtlFrom3rdParty = {
   number: "PII-123123213",
   photo_image_file:
     "resources/test/DummyData/DummyDataSource/DummyPassportOffice/DummyPhoto/fake_passport.jpg",
+  label: "Government verified passport photo",
   exif: `{ ColorModel: RGB, PixelHeight: 800, PixelWidth: 532 }`,
 };
 
@@ -153,8 +149,11 @@ export function passportTransform(
     // instead assuming consumers only work within that data source's silo).
     .addIri(CRED.issuer, INRUPT_3RD_PARTY_PASSPORT_OFFICE_UK.PassportOffice)
 
-    .addStringEnglish(SCHEMA_INRUPT.name, passportDataAsJson.first_name)
-    .addStringEnglish(SCHEMA_INRUPT.familyName, passportDataAsJson.surname)
+    .addStringEnglish("https://schema.org/name", passportDataAsJson.first_name)
+    .addStringEnglish(
+      "https://schema.org/familyName",
+      passportDataAsJson.surname
+    )
 
     .addStringNoLocale(
       INRUPT_3RD_PARTY_PASSPORT_OFFICE_UK.passportNumber,
@@ -196,10 +195,14 @@ export function passportTransform(
     buildThing({
       url: blobMetadataIri,
     })
-      .addIri(RDF.type, SCHEMA_INRUPT.NS("ImageObject"))
-      .addStringNoLocale(RDFS.label, passportDataAsJson.photo_image_file)
-      .addStringNoLocale(SCHEMA_INRUPT.NS("exifData"), passportDataAsJson.exif)
-      .addIri(SCHEMA_INRUPT.image, blobIri)
+      .addIri(RDF.type, "https://schema.org/ImageObject")
+      .addStringNoLocale(RDFS.label, passportDataAsJson.label)
+      .addStringNoLocale(
+        "https://schema.org/isBasedOn",
+        passportDataAsJson.photo_image_file
+      )
+      .addStringNoLocale("https://schema.org/exifData", passportDataAsJson.exif)
+      .addIri("https://schema.org/image", blobIri)
       .build()
   );
 

--- a/src/runEtl.test.ts
+++ b/src/runEtl.test.ts
@@ -165,6 +165,14 @@ describe("ETL process", () => {
     }, 15000);
 
     it("should fail ETL from data source fails", async () => {
+      jest.spyOn(global, "fetch").mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+          })
+        )
+      );
+
       jest.requireMock(
         "@inrupt/solid-client-authn-node"
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -215,7 +223,7 @@ describe("ETL process", () => {
           },
           "getSolidDataset"
         )
-        // We expect a HTTP failure with a response.status code other than
+        // We expect an HTTP failure with a response.status code other than
         // 404!
         .mockRejectedValueOnce(
           mockFetchError("https://example.com/does-not-matter", 401)

--- a/src/runEtl.test.ts
+++ b/src/runEtl.test.ts
@@ -41,13 +41,16 @@ import { Blob } from "node:buffer";
 
 import {
   buildThing,
-  getSolidDataset,
-  deleteSolidDataset,
-  overwriteFile,
   mockSolidDatasetFrom,
   mockFetchError,
 } from "@inrupt/solid-client";
-import { WithResourceInfo } from "@inrupt/solid-client/src/interfaces";
+import type {
+  WithResourceInfo,
+  getSolidDataset,
+  deleteSolidDataset,
+  overwriteFile,
+} from "@inrupt/solid-client";
+
 import { ILoginInputOptions } from "@inrupt/solid-client-authn-core";
 import { INRUPT_TEST } from "@inrupt/vocab-inrupt-test-rdfdatafactory";
 import { createCredentialResourceEmpty } from "./credentialUtil";

--- a/src/solidDatasetUtil.test.ts
+++ b/src/solidDatasetUtil.test.ts
@@ -231,10 +231,7 @@ describe("Solid dataset util functions", () => {
           .build()
       );
 
-      const thing = getThingOfTypeMandatoryOne(
-        dataset,
-        "http://schema.org/Person"
-      );
+      const thing = getThingOfTypeMandatoryOne(dataset, SCHEMA_INRUPT.Person);
       expect(getStringEnglish(thing, SCHEMA_INRUPT.familyName)).toBe(
         personName
       );

--- a/src/solidPod.test.ts
+++ b/src/solidPod.test.ts
@@ -54,7 +54,7 @@ import {
   createContainerAt,
   setThing,
 } from "@inrupt/solid-client";
-import { WithResourceInfo } from "@inrupt/solid-client/src/interfaces";
+import type { WithResourceInfo } from "@inrupt/solid-client";
 import { INRUPT_TEST } from "@inrupt/vocab-inrupt-test-rdfdatafactory";
 import { updateOrInsertResourceInSolidPod } from "./solidPod";
 import { buildDataset } from "./solidDatasetUtil";

--- a/src/solidPod.ts
+++ b/src/solidPod.ts
@@ -52,6 +52,23 @@ import { APPLICATION_NAME } from "./applicationConstant";
 
 const debug = debugModule(`${APPLICATION_NAME}:solidPod`);
 
+/**
+ * Prefixes used for writing RDF in serializations that support prefixes, such
+ * as Turtle. These prefixes simply make the resulting serialization easier
+ * for humans to read.
+ *
+ * @type {{schema: string, void: string, rdf: string, owl: string, xsd: string, skos: string, dcterms: string, rdfs: string, time: string, vann: string}}
+ */
+export const RDF_PREFIXES = {
+  rdf: "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+  rdfs: "http://www.w3.org/2000/01/rdf-schema#",
+  ldp: "http://www.w3.org/ns/ldp#",
+  owl: "http://www.w3.org/2002/07/owl#",
+  xsd: "http://www.w3.org/2001/XMLSchema#",
+  dcterms: "http://purl.org/dc/terms/",
+  schema: "https://schema.org/",
+};
+
 // Type that collects a binary Blob along with its URL and optionally an
 // associated metadata resource that describes that Blob (e.g., the Blog might
 // be an image file, or audio track, with the metadata resource describing
@@ -79,6 +96,7 @@ export async function insertResourceInSolidPod(
   try {
     await saveSolidDatasetAt(resourceIri, resource, {
       fetch: session.fetch,
+      prefixes: RDF_PREFIXES,
       // PMcB: This is a feature request I've submitted to the SDK Team...
       // outputDiagnosticsOnError: false,
     });
@@ -261,6 +279,7 @@ export async function updateOrInsertResourceInSolidPod(
           // eslint-disable-next-line no-await-in-loop
           await saveSolidDatasetAt(resource.url, mergedDataset, {
             fetch: session.fetch,
+            prefixes: RDF_PREFIXES,
             // PMcB: This is a feature request I've submitted to the SDK Team...
             // outputDiagnosticsOnError: false,
           });

--- a/src/solidPod.ts
+++ b/src/solidPod.ts
@@ -48,6 +48,14 @@ import {
   SolidDataset,
 } from "@inrupt/solid-client";
 import { Session } from "@inrupt/solid-client-authn-node";
+import {
+  DCTERMS,
+  LDP,
+  OWL,
+  RDF,
+  RDFS,
+  XSD,
+} from "@inrupt/vocab-common-rdf-rdfdatafactory";
 import { APPLICATION_NAME } from "./applicationConstant";
 
 const debug = debugModule(`${APPLICATION_NAME}:solidPod`);
@@ -60,12 +68,12 @@ const debug = debugModule(`${APPLICATION_NAME}:solidPod`);
  * @type {{schema: string, void: string, rdf: string, owl: string, xsd: string, skos: string, dcterms: string, rdfs: string, time: string, vann: string}}
  */
 export const RDF_PREFIXES = {
-  rdf: "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-  rdfs: "http://www.w3.org/2000/01/rdf-schema#",
-  ldp: "http://www.w3.org/ns/ldp#",
-  owl: "http://www.w3.org/2002/07/owl#",
-  xsd: "http://www.w3.org/2001/XMLSchema#",
-  dcterms: "http://purl.org/dc/terms/",
+  rdf: RDF.NAMESPACE,
+  rdfs: RDFS.NAMESPACE,
+  ldp: LDP.NAMESPACE,
+  owl: OWL.NAMESPACE,
+  xsd: XSD.NAMESPACE,
+  dcterms: DCTERMS.NAMESPACE,
   schema: "https://schema.org/",
 };
 

--- a/src/triplestore.test.ts
+++ b/src/triplestore.test.ts
@@ -18,7 +18,6 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 import { buildThing, createSolidDataset, setThing } from "@inrupt/solid-client";
 
-import { fetch as crossFetch } from "cross-fetch";
 import { config } from "dotenv-flow";
 import { RDF } from "@inrupt/vocab-common-rdf-rdfdatafactory";
 import {
@@ -30,10 +29,9 @@ import {
 import { createCredentialResourceFromEnvironmentVariables } from "./credentialUtil";
 import { buildDataset } from "./solidDatasetUtil";
 
-jest.mock("cross-fetch");
-const mockedFetch = crossFetch as jest.MockedFunction<typeof crossFetch>;
+const mockedFetch = jest.spyOn(global, "fetch");
 
-// Load environment variables from .env.test.local if available:
+// Load environment variables from .env.test.local, if available:
 config({
   default_node_env: process.env.NODE_ENV || "test",
   path: "resources/test",

--- a/src/triplestore.test.ts
+++ b/src/triplestore.test.ts
@@ -20,7 +20,7 @@ import { buildThing, createSolidDataset, setThing } from "@inrupt/solid-client";
 
 import { fetch as crossFetch } from "cross-fetch";
 import { config } from "dotenv-flow";
-import { RDF, SCHEMA_INRUPT } from "@inrupt/vocab-common-rdf-rdfdatafactory";
+import { RDF } from "@inrupt/vocab-common-rdf-rdfdatafactory";
 import {
   clearTriplestore,
   insertIntoTriplestoreResources,
@@ -128,7 +128,7 @@ describe("triplestore", () => {
         blob: new Blob(),
         metadata: buildDataset(
           buildThing({ url: "https://inrupt.com/vocab/first" })
-            .addIri(RDF.type, SCHEMA_INRUPT.Person)
+            .addIri(RDF.type, "https://schema.org/Person")
             .build()
         ),
       });
@@ -163,7 +163,7 @@ describe("triplestore", () => {
       resources.push(
         buildDataset(
           buildThing({ url: "https://inrupt.com/vocab/first" })
-            .addIri(RDF.type, SCHEMA_INRUPT.Person)
+            .addIri(RDF.type, "https://schema.org/Person")
             .build()
         )
       );
@@ -185,7 +185,7 @@ describe("triplestore", () => {
 
       const resource = buildDataset(
         buildThing({ url: "https://inrupt.com/vocab/first" })
-          .addIri(RDF.type, SCHEMA_INRUPT.Person)
+          .addIri(RDF.type, "https://schema.org/Person")
           .build()
       );
 
@@ -208,7 +208,7 @@ describe("triplestore", () => {
 
       const thing = buildDataset(
         buildThing({ url: "https://inrupt.com/vocab/first" })
-          .addIri(RDF.type, SCHEMA_INRUPT.Person)
+          .addIri(RDF.type, "https://schema.org/Person")
           .build()
       );
 
@@ -230,7 +230,7 @@ describe("triplestore", () => {
 
       const thing = buildDataset(
         buildThing({ url: "https://inrupt.com/vocab/first" })
-          .addIri(RDF.type, SCHEMA_INRUPT.Person)
+          .addIri(RDF.type, "https://schema.org/Person")
           .build()
       );
 

--- a/src/triplestore.ts
+++ b/src/triplestore.ts
@@ -18,7 +18,6 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import debugModule from "debug";
-import { fetch as crossFetch } from "cross-fetch";
 
 import { SolidDataset } from "@inrupt/solid-client";
 import { INRUPT_COMMON } from "@inrupt/vocab-etl-tutorial-bundle-all-rdfdatafactory";
@@ -61,7 +60,7 @@ export async function clearTriplestore(
     namedGraph === "default" ? "CLEAR ALL" : `CLEAR GRAPH <${namedGraph}>`;
 
   // We have guard above against null or empty repo.
-  return crossFetch(repoEndpointUpdate as string, {
+  return fetch(repoEndpointUpdate as string, {
     method: "POST",
     body: command,
     headers: {
@@ -117,7 +116,7 @@ ${graphWrappedInsertStatement}
   // debug(`Attempting to write to triplestore:\n${fullBody}`);
 
   // We have guard above against null or empty repo.
-  return crossFetch(repoEndpointUpdate as string, {
+  return fetch(repoEndpointUpdate as string, {
     method: "POST",
     body: fullBody,
     headers: {

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -17,11 +17,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// We need to import Response because it's not a global in Node.
-// We need to rename Response because otherwise ESLint thinks we're
-// re-defining a global - d'oh!
-import { Response as CrossFetchResponse } from "cross-fetch";
-
 import { buildThing } from "@inrupt/solid-client";
 import {
   describeCollectionOfResources,
@@ -53,7 +48,7 @@ describe("Util functions", () => {
 
   describe("handle HTTP response containing JSON", () => {
     it("should succeed", async () => {
-      const res = new CrossFetchResponse(
+      const res = new Response(
         JSON.stringify({
           data: "stuff...",
           success: true,
@@ -65,7 +60,7 @@ describe("Util functions", () => {
     });
 
     it("should fail if not success", async () => {
-      const res = new CrossFetchResponse("An error message", {
+      const res = new Response("An error message", {
         status: 500,
       });
 
@@ -78,14 +73,14 @@ describe("Util functions", () => {
   describe("handle HTTP response containing a Blob", () => {
     it("should succeed", async () => {
       const blob = "hello world!";
-      const res = new CrossFetchResponse(blob);
+      const res = new Response(blob);
 
       const response = await handleResponseBlob(res, dataSource, endpoint);
       expect(await response.text()).toEqual(blob);
     });
 
     it("should fail if not success", async () => {
-      const res = new CrossFetchResponse("An error message", {
+      const res = new Response("An error message", {
         status: 500,
       });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": ".",                           /* Redirect output structure to the directory. */
-    "rootDir": "src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */


### PR DESCRIPTION
WORK-IN-PROGRESS:

Jest unit tests fail (`npm test`), due to the TextEncoder issues we saw long ago.
Also, code is pulling in old generated artifacts which use the 'old' HTTP namespace for Schema.org - we should re-generate and publish latest versions (long overdue anyway!).